### PR TITLE
Allow user to direct video output to a different directory

### DIFF
--- a/PlexComskip.py
+++ b/PlexComskip.py
@@ -95,6 +95,7 @@ if sys.platform != 'win32':
 # On to the actual work.
 try:
   video_path = sys.argv[1]
+  output_path = sys.argv[2]
   temp_dir = os.path.join(TEMP_ROOT, session_uuid)
   os.makedirs(temp_dir)
   os.chdir(temp_dir)
@@ -103,8 +104,10 @@ try:
   logging.info('Using temp dir: %s' % temp_dir)
   logging.info('Using input file: %s' % video_path)
 
+  output_video_dir = os.path.dirname(video_path)
+  if output_path:
+    output_video_dir = os.path.dirname(output_path)
 
-  original_video_dir = os.path.dirname(video_path)
   video_basename = os.path.basename(video_path)
   video_name, video_ext = os.path.splitext(video_basename)
 
@@ -205,8 +208,8 @@ try:
     cleanup_and_exit(temp_dir, SAVE_ALWAYS)
   elif input_size and 1.1 > float(output_size) / float(input_size) > 0.5:
     logging.info('Output file size looked sane, we\'ll replace the original: %s -> %s' % (sizeof_fmt(input_size), sizeof_fmt(output_size)))
-    logging.info('Copying the output file into place: %s -> %s' % (video_basename, original_video_dir))
-    shutil.copy(os.path.join(temp_dir, video_basename), original_video_dir)
+    logging.info('Copying the output file into place: %s -> %s' % (video_basename, output_video_dir))
+    shutil.copy(os.path.join(temp_dir, video_basename), output_video_dir)
     cleanup_and_exit(temp_dir, SAVE_ALWAYS)
   else:
     logging.info('Output file size looked wonky (too big or too small); we won\'t replace the original: %s -> %s' % (sizeof_fmt(input_size), sizeof_fmt(output_size)))

--- a/PlexComskip.py
+++ b/PlexComskip.py
@@ -95,7 +95,6 @@ if sys.platform != 'win32':
 # On to the actual work.
 try:
   video_path = sys.argv[1]
-  output_path = sys.argv[2]
   temp_dir = os.path.join(TEMP_ROOT, session_uuid)
   os.makedirs(temp_dir)
   os.chdir(temp_dir)
@@ -105,8 +104,9 @@ try:
   logging.info('Using input file: %s' % video_path)
 
   output_video_dir = os.path.dirname(video_path)
-  if output_path:
-    output_video_dir = os.path.dirname(output_path)
+  if sys.argv[2:]:
+    logging.info('Output will be put in: %s' % sys.argv[2])
+    output_video_dir = os.path.dirname(sys.argv[2])
 
   video_basename = os.path.basename(video_path)
   video_name, video_ext = os.path.splitext(video_basename)


### PR DESCRIPTION
I record shows OTA using Plex DVR, then automatically process these files.

I do this by recording to one `DVR` library then running PlexComskip and putting the resulting files into the main `TV Shows` library.

Instead of manually moving these files, I added the optional parameter to copy from the temp directory into a new directory instead of overwriting the original.

